### PR TITLE
Use allocator api2 0.3 properly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-cross: true, rust-toolchain: stable, features: "" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" }
-          - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" }
+          # - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" } # Enterprise only.
           - { os: macos-13, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: stable, features: "" } # x86
           - { os: macos-14, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: stable, features: "" } # M1
           # Nightly
@@ -31,7 +31,7 @@ jobs:
           - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-cross: true, rust-toolchain: nightly, features: "nightly" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" }
-          - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" }
+          # - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" } # Enterprise only.
           - { os: macos-13, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: nightly, features: "nightly" } # x86
           - { os: macos-14, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: nightly, features: "nightly" } # M1
 
@@ -42,9 +42,6 @@ jobs:
 
       - name: Run Tests and Upload Coverage
         uses: Reloaded-Project/devops-rust-test-and-coverage@v1
-        # Currently unsupported due to no native runner.
-        # Native runner currently only available in enterprise.
-        if: matrix.target != 'aarch64-pc-windows-msvc'
         with:
           upload-coverage: true
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -52,6 +49,7 @@ jobs:
           use-cross: ${{ matrix.use-cross }}
           rust-toolchain: ${{ matrix.rust-toolchain }}
           features: ${{ matrix.features }}
+          install-binstall: true
 
       # Note: The GitHub Runner Images will contain an up to date Rust Stable Toolchain
       #       thus as per recommendation of cargo-semver-checks, we're using stable here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-allocator-api"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "A safe wrapper around the `allocator_api`'s Allocator trait."
 repository = "https://github.com/Sewer56/safe-allocator-api"

--- a/README.MD
+++ b/README.MD
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-safe-allocator-api = "0.1.0"
+safe-allocator-api = "0.5.0"
 ```
 
 ## Examples

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@ safe-allocator-api = "0.5.0"
 ```rust
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 
-use safe_allocator_api::allocator_api::*;
+use safe_allocator_api::prelude::*;
 use safe_allocator_api::RawAlloc;
 
 fn allocate_example() -> Result<(), AllocError> {
@@ -61,7 +61,7 @@ fn allocate_example() -> Result<(), AllocError> {
 ```rust
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 
-use safe_allocator_api::allocator_api::*;
+use safe_allocator_api::prelude::*;
 use safe_allocator_api::RawAlloc;
 
 fn zero_initialized_example() -> Result<(), AllocError> {
@@ -84,7 +84,7 @@ fn zero_initialized_example() -> Result<(), AllocError> {
 ```rust
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 
-use safe_allocator_api::allocator_api::*;
+use safe_allocator_api::prelude::*;
 use safe_allocator_api::RawAlloc;
 
 fn grow_and_shrink_example() -> Result<(), AllocError> {
@@ -109,7 +109,7 @@ fn grow_and_shrink_example() -> Result<(), AllocError> {
 ```rust
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 
-use safe_allocator_api::allocator_api::*;
+use safe_allocator_api::prelude::*;
 use safe_allocator_api::RawAlloc;
 
 fn custom_allocator_example() -> Result<(), AllocError> {

--- a/src/allocator_api.rs
+++ b/src/allocator_api.rs
@@ -1,6 +1,4 @@
 //! Bindings for allocator_api that allow usage within both nightly and stable.
 
-#[cfg(feature = "nightly")]
-pub use alloc::alloc::*;
-#[cfg(not(feature = "nightly"))]
-pub use allocator_api2::alloc::*;
+// Import and re-export allocator types from internal prelude
+pub use crate::prelude::{Allocator, Layout, AllocError, Global};

--- a/src/allocator_api.rs
+++ b/src/allocator_api.rs
@@ -1,4 +1,0 @@
-//! Bindings for allocator_api that allow usage within both nightly and stable.
-
-// Import and re-export allocator types from internal prelude
-pub use crate::prelude::{Allocator, Layout, AllocError, Global};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-// Internal prelude module for conditional allocator imports
-mod prelude;
-
 pub mod raw_alloc;
 pub use raw_alloc::*;
+pub mod prelude;
 pub use prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+// Internal prelude module for conditional allocator imports
+mod prelude;
+
 pub mod raw_alloc;
 pub use raw_alloc::*;
-pub mod allocator_api;
-pub use allocator_api::*;
+pub use prelude::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,25 @@
+//! Internal prelude module for allocator API types.
+//!
+//! This module centralizes the conditional imports for allocator-related types,
+//! allowing the rest of the crate to use consistent types regardless of whether
+//! the nightly feature is enabled or not.
+
+#[cfg(not(feature = "nightly"))]
+pub use allocator_api2::alloc::Allocator;
+#[cfg(feature = "nightly")]
+pub use std::alloc::Allocator;
+
+#[cfg(not(feature = "nightly"))]
+pub use allocator_api2::alloc::Layout;
+#[cfg(feature = "nightly")]
+pub use core::alloc::Layout;
+
+#[cfg(not(feature = "nightly"))]
+pub use allocator_api2::alloc::AllocError;
+#[cfg(feature = "nightly")]
+pub use std::alloc::AllocError;
+
+#[cfg(not(feature = "nightly"))]
+pub use allocator_api2::alloc::Global;
+#[cfg(feature = "nightly")]
+pub use std::alloc::Global;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-//! Internal prelude module for allocator API types.
+//! Prelude module for allocator API types.
 //!
 //! This module centralizes the conditional imports for allocator-related types,
 //! allowing the rest of the crate to use consistent types regardless of whether

--- a/src/raw_alloc.rs
+++ b/src/raw_alloc.rs
@@ -3,8 +3,8 @@
 //! This crate provides a safe interface for working with raw allocations while maintaining
 //! the same error handling semantics as the underlying allocation APIs.
 use crate::prelude::*;
-use core::ptr::NonNull;
 use core::fmt;
+use core::ptr::NonNull;
 
 /// A safe wrapper around a raw allocation with known layout.
 ///
@@ -57,7 +57,7 @@ impl<A: Allocator> RawAlloc<A> {
     /// # Example
     ///
     /// ```rust
-    /// #![feature(allocator_api)]
+    /// #![cfg_attr(feature = "nightly", feature(allocator_api))]
     ///
     /// use core::alloc::Layout;
     /// use safe_allocator_api::prelude::*;

--- a/src/raw_alloc.rs
+++ b/src/raw_alloc.rs
@@ -4,7 +4,7 @@
 //! the same error handling semantics as the underlying allocation APIs.
 use crate::allocator_api::*;
 use core::ptr::NonNull;
-use core::{alloc::Layout, fmt};
+use core::fmt;
 
 /// A safe wrapper around a raw allocation with known layout.
 ///

--- a/src/raw_alloc.rs
+++ b/src/raw_alloc.rs
@@ -59,7 +59,6 @@ impl<A: Allocator> RawAlloc<A> {
     /// ```rust
     /// #![cfg_attr(feature = "nightly", feature(allocator_api))]
     ///
-    /// use core::alloc::Layout;
     /// use safe_allocator_api::prelude::*;
     /// use safe_allocator_api::RawAlloc;
     ///

--- a/src/raw_alloc.rs
+++ b/src/raw_alloc.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides a safe interface for working with raw allocations while maintaining
 //! the same error handling semantics as the underlying allocation APIs.
-use crate::allocator_api::*;
+use crate::prelude::*;
 use core::ptr::NonNull;
 use core::fmt;
 
@@ -60,7 +60,7 @@ impl<A: Allocator> RawAlloc<A> {
     /// #![feature(allocator_api)]
     ///
     /// use core::alloc::Layout;
-    /// use safe_allocator_api::allocator_api::*;
+    /// use safe_allocator_api::prelude::*;
     /// use safe_allocator_api::RawAlloc;
     ///
     /// let layout = Layout::new::<u64>();
@@ -118,7 +118,7 @@ impl<A: Allocator> RawAlloc<A> {
     /// ```rust
     /// #![cfg_attr(feature = "nightly", feature(allocator_api))]
     ///
-    /// use safe_allocator_api::allocator_api::*;
+    /// use safe_allocator_api::prelude::*;
     /// use safe_allocator_api::RawAlloc;
     ///
     /// let layout = Layout::array::<u8>(100).unwrap();
@@ -195,7 +195,7 @@ impl<A: Allocator> RawAlloc<A> {
     /// ```rust
     /// #![cfg_attr(feature = "nightly", feature(allocator_api))]
     ///
-    /// use safe_allocator_api::allocator_api::*;
+    /// use safe_allocator_api::prelude::*;
     /// use safe_allocator_api::RawAlloc;
     ///
     /// let layout = Layout::array::<u8>(200).unwrap();
@@ -256,7 +256,7 @@ impl<A: Allocator> RawAlloc<A> {
     /// ```rust
     /// #![cfg_attr(feature = "nightly", feature(allocator_api))]
     ///
-    /// use safe_allocator_api::allocator_api::*;
+    /// use safe_allocator_api::prelude::*;
     /// use safe_allocator_api::RawAlloc;
     ///
     /// let layout = Layout::array::<u8>(100).unwrap();
@@ -278,7 +278,7 @@ impl<A: Allocator> RawAlloc<A> {
     /// ```rust
     /// #![cfg_attr(feature = "nightly", feature(allocator_api))]
     ///
-    /// use safe_allocator_api::allocator_api::*;
+    /// use safe_allocator_api::prelude::*;
     /// use safe_allocator_api::RawAlloc;
     ///
     /// let layout = Layout::array::<u8>(100).unwrap();


### PR DESCRIPTION
This crate did not cleanly migrate from 0.2 to 0.3.
You're not supposed to always use `allocator_api2`, instead you're meant to have a conditional behind a nightly flag, this fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a unified prelude for allocator-related types to simplify imports across stable and nightly builds.

- Refactor
  - Replaced the previous allocator_api surface with the new prelude. Update imports from crate::allocator_api::* to crate::prelude::*.

- Documentation
  - Updated README examples to use the new prelude and refreshed dependency version references.

- Chores
  - Bumped package version to 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->