### PR TITLE
Updated: CI Runners for safe-allocator-api

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,8 @@ jobs:
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" }
           # - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: false, rust-toolchain: stable, features: "" } # Enterprise only.
-          - { os: macos-13, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: stable, features: "" } # x86
-          - { os: macos-14, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: stable, features: "" } # M1
+          - { os: macos-15-intel, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: stable, features: "" } # x86
+          - { os: macos-latest, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: stable, features: "" } # M1
           # Nightly
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, rust-toolchain: nightly, features: "nightly" }
           - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-cross: false, rust-toolchain: nightly, features: "nightly" }
@@ -32,8 +32,8 @@ jobs:
           - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" }
           - { os: windows-latest, target: i686-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" }
           # - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: false, rust-toolchain: nightly, features: "nightly" } # Enterprise only.
-          - { os: macos-13, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: nightly, features: "nightly" } # x86
-          - { os: macos-14, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: nightly, features: "nightly" } # M1
+          - { os: macos-15-intel, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: nightly, features: "nightly" } # x86
+          - { os: macos-latest, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: nightly, features: "nightly" } # M1
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/safe-allocator-api/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI macOS build matrix to use current Intel and Apple Silicon runners for both stable and nightly pipelines, aligning with the latest macOS versions.
  - Enhances build reliability and coverage across architectures, reducing flakiness and improving future compatibility.
  - No changes to features or user-facing behavior; this is an internal maintenance improvement to keep the release pipeline up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->